### PR TITLE
上架：同步 Edge 商店链接与简体中文清单

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,21 @@
 
 ---
 
-## 🚀 安装（已上架 Chrome 商店）
+<a id="store-install"></a>
 
-已通过商店审核并公开发布（v0.1.0，2026-08-15）：
+## 🚀 安装（Chrome 与 Edge 商店）
+
+v0.1.0 已通过两家浏览器商店审核并公开发布：
 
 [![Chrome Web Store](https://img.shields.io/badge/Chrome_Web_Store-Digest_for_Bilibili-4285F4?style=for-the-badge&logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/digest-for-bilibili/cfndfabkpfgihcgknbgfnkjlmndhhmfc)
+[![Microsoft Edge Add-ons](https://img.shields.io/badge/Microsoft_Edge_Add--ons-Digest_for_Bilibili-0078D7?style=for-the-badge&logo=microsoftedge&logoColor=white)](https://microsoftedge.microsoft.com/addons/detail/digest-for-bilibili/jlfmjhkcbnkgghefieaagkcccjojmnkm)
 
-👉 **点击上方蓝色按钮**，在打开的商店页面点「Add to Chrome / 添加到 Chrome」即可安装。
+| 商店 | 上线日期 | 安装链接 |
+| --- | --- | --- |
+| Chrome Web Store | 2026-08-15 | [安装 Digest for Bilibili](https://chromewebstore.google.com/detail/digest-for-bilibili/cfndfabkpfgihcgknbgfnkjlmndhhmfc) |
+| Microsoft Edge Add-ons | 2026-08-17 | [安装 Digest for Bilibili](https://microsoftedge.microsoft.com/addons/detail/digest-for-bilibili/jlfmjhkcbnkgghefieaagkcccjojmnkm) |
 
-> 商店搜索索引有延迟，刚上架时搜索可能还搜不到——用上方按钮直达商店，不影响安装。
+点击对应商店的徽章或表格链接即可安装。商店搜索索引可能稍晚更新，直达链接可正常使用。
 
 ---
 
@@ -58,7 +64,7 @@ AI 会把当时那句字幕整理成通顺的一句话，笔记卡片支持回�
 
 ## 安装
 
-商店安装见顶部 [🚀 安装](#-安装已上架-chrome-商店)。
+商店安装见顶部 [🚀 安装](#store-install)。
 
 Chrome 和 Edge 用的是同一份代码、同一个安装包，功能没有差别。
 两者都需要 116 及以上的版本——这是侧边栏 API 的门槛。

--- a/STORE-LISTING.md
+++ b/STORE-LISTING.md
@@ -3,6 +3,13 @@
 Chrome 应用商店与 Edge 加载项共用这一份，改动请两边同步。
 这个文件不进安装包（`scripts/package.sh` 走白名单），只作为提交时的稿件来源。
 
+## 发布状态
+
+| 商店 | 版本 | 上线日期 | 链接 |
+| --- | --- | --- | --- |
+| Chrome Web Store | 0.1.0 | 2026-08-15 | https://chromewebstore.google.com/detail/digest-for-bilibili/cfndfabkpfgihcgknbgfnkjlmndhhmfc |
+| Microsoft Edge Add-ons | 0.1.0 | 2026-08-17 | https://microsoftedge.microsoft.com/addons/detail/digest-for-bilibili/jlfmjhkcbnkgghefieaagkcccjojmnkm |
+
 **不要在说明里罗列模型服务商的名字。** 0.1.0 首次提交时，「使用方法」里列了
 DeepSeek、OpenAI、Anthropic、Gemini、Kimi、智谱、通义千问、硅基流动、OpenRouter
 九个预设名，被 Chrome 应用商店判为「关键字垃圾内容」退回（政策禁止过多或不相关的
@@ -34,7 +41,7 @@ Digest for Bilibili 在 B 站播放页旁边打开一个侧边栏，把当前视
 3. 侧边栏自动加载该视频的字幕。顶部在「字幕 / 概览 / 笔记」三个标签间切换。
 
 隐私
-本扩展没有服务器，开发者不接收、也无法访问你的任何数据。设置、字幕缓存和笔记全部写入 chrome.storage.local，只留在你这台设备上，不使用会同步到浏览器账号的 chrome.storage.sync，卸载扩展时由浏览器一并清除。使用 AI 功能时，相关字幕文本会随请求发往你自己在设置页填写的那个模型服务地址，除此之外不向任何地址发送数据。不埋点、不接入任何分析或广告 SDK、不读取浏览历史、不加载远程代码。完整隐私政策：https://github.com/biuworks/bilibili-digest/blob/main/PRIVACY.md
+本扩展没有开发者运营的服务器。开发者不接收、不存储、也不访问用户数据。设置、字幕缓存和笔记全部保存在扩展的本地存储空间，仅留在用户当前设备上，不使用浏览器账号同步存储；卸载扩展时，这些本地数据会由浏览器一并清除。使用 AI 功能时，相关字幕文本、选中的文字和视频标题会发送到用户在设置页指定的模型服务地址，数据仅用于完成用户主动发起的 AI 功能。扩展没有分析或广告 SDK，不记录浏览历史，也不加载远程代码。完整隐私政策：https://github.com/biuworks/bilibili-digest/blob/main/PRIVACY.md
 
 权限说明
 • 读取和更改 bilibili.com 上的数据 — 在播放页注入「笔记」按钮、识别当前视频编号，并从 B 站官方接口下载字幕文件。仅对视频播放页生效。
@@ -42,7 +49,7 @@ Digest for Bilibili 在 B 站播放页旁边打开一个侧边栏，把当前视
 • 访问你指定的 AI 服务地址 — 安装时不申请。你在设置页点「保存并授权」时，才按你填写的那一个域名单独申请，可以随时在浏览器的扩展详情页收回。
 
 说明
-本扩展是个人开发的第三方工具，与 bilibili 官方没有关联，也未获其授权或背书。AI 功能需要你自备模型服务的 API 密钥，扩展本身不提供 AI 额度。字幕能否读取取决于 B 站是否为该视频提供字幕轨，AI 字幕通常需要你已登录 B 站。
+本扩展是个人开发的第三方工具，与 bilibili 官方没有关联，也未获其授权或背书。AI 功能使用用户自己的模型服务和 API 密钥，相关调用额度由用户选择的模型服务承担。字幕读取取决于 B 站是否为该视频提供字幕轨，部分 AI 字幕需要用户已登录 B 站。
 
 反馈
 Bug 与建议请提交到 https://github.com/biuworks/bilibili-digest/issues

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1,0 +1,8 @@
+{
+  "extensionName": {
+    "message": "Digest for Bilibili"
+  },
+  "extensionDescription": {
+    "message": "把 B 站视频变成学习资源：字幕阅读、双语对照、AI 章节概览、划词解释，以及带时间戳的笔记。自带模型密钥，笔记与缓存只存在本地。"
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,10 @@
 {
   "manifest_version": 3,
-  "name": "Digest for Bilibili",
+  "default_locale": "zh_CN",
+  "name": "__MSG_extensionName__",
   "version": "0.1.0",
   "minimum_chrome_version": "116",
-  "description": "把 B 站视频变成学习资源：字幕阅读、双语对照、AI 章节概览、划词解释，以及带时间戳的笔记。自带模型密钥，笔记与缓存只存在本地。",
+  "description": "__MSG_extensionDescription__",
   "permissions": ["sidePanel", "storage", "tabs"],
   "host_permissions": [
     "https://www.bilibili.com/*",

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -26,7 +26,7 @@ FILES=(
   icons/icon128.png
   LICENSE
 )
-DIRS=(lib prompts)
+DIRS=(lib prompts _locales)
 
 version=$(node -p "require('./manifest.json').version")
 out="dist/digest-for-bilibili-${version}.zip"

--- a/tests/manifest.test.js
+++ b/tests/manifest.test.js
@@ -10,6 +10,26 @@ const readText = (file) => fs.readFileSync(path.join(root, file), "utf8");
 const exists = (file) => fs.existsSync(path.join(root, file));
 
 const manifest = readJson("manifest.json");
+const localizedMessages = readJson(
+  `_locales/${manifest.default_locale}/messages.json`,
+);
+const resolveManifestText = (value) => {
+  const match = /^__MSG_([^_].*)__$/.exec(value);
+  return match ? localizedMessages[match[1]]?.message : value;
+};
+const manifestName = resolveManifestText(manifest.name);
+const manifestDescription = resolveManifestText(manifest.description);
+
+test("商店主语言声明为简体中文并随安装包发布本地化消息", () => {
+  assert.equal(manifest.default_locale, "zh_CN");
+  assert.equal(manifest.name, "__MSG_extensionName__");
+  assert.equal(manifest.description, "__MSG_extensionDescription__");
+
+  assert.equal(localizedMessages.extensionName.message, "Digest for Bilibili");
+  assert.ok(localizedMessages.extensionDescription.message.length > 0);
+  assert.ok(localizedMessages.extensionDescription.message.length <= 132);
+  assert.match(readText("scripts/package.sh"), /DIRS=\([^)]*_locales[^)]*\)/);
+});
 
 test("是一份 MV3 清单", () => {
   assert.equal(manifest.manifest_version, 3);
@@ -44,24 +64,24 @@ test("侧边栏全局可用，图标点击交给浏览器处理", () => {
 test("同一份清单能投 Chrome 应用商店和 Edge 加载项", () => {
   // 这两条都是 Edge 认证会直接打回的硬性要求。
   assert.equal(manifest.update_url, undefined, "商店版清单不能带 update_url");
-  for (const field of [manifest.name, manifest.description]) {
+  for (const field of [manifestName, manifestDescription]) {
     assert.doesNotMatch(field, /chrome/i, "名称和描述里不能出现 Chrome");
   }
 });
 
 test("描述不超过 132 字符，且不宣传尚未实现的功能", () => {
   // 商店对这个字段有 132 字符的硬上限，超了要等到上传那一刻才报错。
-  assert.ok(manifest.description.length > 0);
+  assert.ok(manifestDescription.length > 0);
   assert.ok(
-    manifest.description.length <= 132,
-    `描述有 ${manifest.description.length} 字符，超过商店 132 的上限`,
+    manifestDescription.length <= 132,
+    `描述有 ${manifestDescription.length} 字符，超过商店 132 的上限`,
   );
 
   // 描述先于实现出现，就是在向用户承诺一个装完找不到的功能。
   // 认这个消息名而不是「translat」这几个字母：注释里提一句翻译不算接线。
   const translationWired = readText("sidepanel.js").includes("translateSegments");
   if (!translationWired) {
-    for (const field of [manifest.description, readJson("package.json").description]) {
+    for (const field of [manifestDescription, readJson("package.json").description]) {
       assert.doesNotMatch(
         field,
         /bilingual|translation/i,


### PR DESCRIPTION
## What changed

- add the published Microsoft Edge Add-ons badge, link, and release date to the README
- record both Chrome Web Store and Microsoft Edge Add-ons releases in the shared store listing source
- declare `zh_CN` through manifest localization so Partner Center detects Simplified Chinese
- package `_locales` and cover the localized manifest fields with regression tests
- keep the shared store description browser-neutral

## Why

Digest for Bilibili v0.1.0 is now published in Microsoft Edge Add-ons. The repository and package metadata should reflect both live distribution channels.

## Checks

- `npm test` — 12/12 test files passed
- `npm run package` — generated a 32-entry v0.1.0 ZIP
- verified both live store URLs are present in `README.md` and `STORE-LISTING.md`
- verified the ZIP contains `_locales/zh_CN/messages.json`
