### PR TITLE
保留最新六份回滚材料

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ dist/
 .DS_Store
 *.log
 
+# 本地测试、补丁与回滚记录（由 scripts/prune-artifacts.sh 保留最新 6 份）
+artifacts/
+
 # 上游参考源码是本地 git clone，不进入本仓库历史
 # （获取：git clone https://github.com/zarazhangrui/youtube-digest references/youtube-digest）
 references/

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "license": "MIT",
   "scripts": {
     "test": "node --test tests/*.test.js",
-    "package": "bash scripts/package.sh"
+    "posttest": "npm run artifacts:prune",
+    "package": "bash scripts/package.sh",
+    "postpackage": "npm run artifacts:prune",
+    "artifacts:prune": "bash scripts/prune-artifacts.sh"
   }
 }

--- a/scripts/prune-artifacts.sh
+++ b/scripts/prune-artifacts.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARTIFACTS_DIR="${1:-${ROOT_DIR}/artifacts}"
+KEEP="${2:-6}"
+
+if [[ ! "${KEEP}" =~ ^[0-9]+$ ]]; then
+  echo "保留数量必须是非负整数：${KEEP}" >&2
+  exit 2
+fi
+
+if [[ ! -d "${ARTIFACTS_DIR}" ]]; then
+  echo "没有 artifacts 目录，无需清理：${ARTIFACTS_DIR}"
+  exit 0
+fi
+
+# 一个一级子目录代表一份完整回滚材料；根目录文件不纳入版本计数。
+mapfile -d '' versions < <(
+  find "${ARTIFACTS_DIR}" -mindepth 1 -maxdepth 1 -type d \
+    -printf '%T@\t%p\0' \
+    | sort -z -t $'\t' -k1,1nr -k2,2r
+)
+
+total=${#versions[@]}
+deleted=0
+for ((index = KEEP; index < total; index += 1)); do
+  version_path="${versions[index]#*$'\t'}"
+  rm -rf -- "${version_path}"
+  ((deleted += 1))
+done
+
+retained=$((total - deleted))
+echo "artifacts：删除 ${deleted} 个旧版本，保留 ${retained} 个最新版本。"

--- a/tests/prune-artifacts.test.js
+++ b/tests/prune-artifacts.test.js
@@ -1,0 +1,45 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const root = path.resolve(__dirname, "..");
+const script = path.join(root, "scripts", "prune-artifacts.sh");
+
+test("回滚材料只保留修改时间最新的 6 个版本", () => {
+  const artifacts = fs.mkdtempSync(path.join(os.tmpdir(), "bilibili-artifacts-"));
+
+  try {
+    fs.writeFileSync(path.join(artifacts, "README.txt"), "根目录文件不属于版本");
+    for (let index = 1; index <= 8; index += 1) {
+      const version = path.join(artifacts, `version-${index}`);
+      fs.mkdirSync(version);
+      fs.writeFileSync(path.join(version, "rollback.sh"), "#!/bin/sh\n");
+      const timestamp = new Date(`2026-01-${String(index).padStart(2, "0")}T00:00:00Z`);
+      fs.utimesSync(version, timestamp, timestamp);
+    }
+
+    const result = spawnSync("bash", [script, artifacts, "6"], {
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(
+      fs.readdirSync(artifacts).sort(),
+      [
+        "README.txt",
+        "version-3",
+        "version-4",
+        "version-5",
+        "version-6",
+        "version-7",
+        "version-8",
+      ],
+    );
+    assert.match(result.stdout, /删除 2 个旧版本，保留 6 个最新版本/);
+  } finally {
+    fs.rmSync(artifacts, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 变更内容

- 将本地 `artifacts/` 加入 Git 忽略规则
- 新增回滚材料清理脚本，按一级目录修改时间保留最新 6 份
- 在测试和打包完成后自动执行清理
- 新增回归测试，覆盖“8 份材料删除最旧 2 份”及根目录文件保留行为

## 原因

回滚与验证材料此前会持续累积，同时作为未跟踪目录出现在工作区中。该改动限制本地材料数量，保留近期回滚能力并避免长期占用磁盘。

## 验证

- `npm test`
- 13 项测试通过，0 项失败
- `posttest` 清理流程执行成功